### PR TITLE
Refactor Driver

### DIFF
--- a/gRPC/sdk_performer.proto
+++ b/gRPC/sdk_performer.proto
@@ -46,11 +46,10 @@ message CreateConnectionResponse {
 }
 
 message SdkCreateRequest {
-    repeated SdkCommand commands = 1;
-
+    SdkCommand command = 1;
     string name = 2;
-
     string clusterConnectionId=3;
+    int32 count = 4;
 }
 
 message SdkCommandResult {

--- a/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/SdkOperation.java
+++ b/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/SdkOperation.java
@@ -22,8 +22,8 @@ public class SdkOperation {
     ) {
         this.name = req.getName();
 
-        for (SdkCommand command : req.getCommandsList()) {
-            performOperation(connection, command);
+        for (int i=0; i< req.getCount(); i++) {
+            performOperation(connection, req.getCommands());
         }
         SdkCommandResult.Builder response = SdkCommandResult.getDefaultInstance().newBuilderForType();
         return response.build();

--- a/test-suites/goInsert.yaml
+++ b/test-suites/goInsert.yaml
@@ -1,15 +1,8 @@
 ---
-<<<<<<< Updated upstream
 runtime: "5m"
 implementation:
   language: "go"
   version: "2.3.3"
-=======
-runtime: "10m"
-implementation:
-  language: "go"
-  version: "2.3.5"
->>>>>>> Stashed changes
 variables:
   predefined:
   - name: "horizontal_scaling"
@@ -32,11 +25,7 @@ connections:
     password: "password"
     dbName: "perf"
 runs:
-<<<<<<< Updated upstream
 - uuid: "097572b1-0ab4-435a-9250-5c6cca8d23e5"
-=======
-- uuid: "097572b1-0ab4-435a-9250-5c6cca8d23d4"
->>>>>>> Stashed changes
   description: "Insert 50"
   operations:
   - op: "INSERT"

--- a/test-suites/javaInsert.yaml
+++ b/test-suites/javaInsert.yaml
@@ -1,8 +1,8 @@
 ---
-runtime: "5m"
+runtime: "10s"
 implementation:
   language: "java"
-  version: "3.1.3"
+  version: "3.1.4"
 variables:
   predefined:
   - name: "horizontal_scaling"
@@ -25,7 +25,7 @@ connections:
     password: "password"
     dbName: "perf"
 runs:
-- uuid: "097572b1-0ab4-435a-9250-5c6cca8d23d1"
+- uuid: "097572b1-0ab4-435a-9250-5c6cca8d23f1"
   description: "Insert 50"
   operations:
   - op: "INSERT"


### PR DESCRIPTION
If the cpunt variable was set to 50 in the old version then the Driver
would send 50 instructions to the performer, as this doesn't really
scale well the driver now sends one instruction and a number of times to
complete it. The performer then does the command in a loop for that
number of times
it

Change-Id: Idfdb4f331e110acf353ef8904cfce58b95c02d1b