### PR TITLE
Driver Set Bucket

### DIFF
--- a/gRPC/sdk_performer.proto
+++ b/gRPC/sdk_performer.proto
@@ -27,6 +27,7 @@ message CreateConnectionRequest {
     string clusterHostname=1;
     string clusterUsername=2;
     string clusterPassword=3;
+    string bucketName=4;
 }
 
 // Returns the capabilities of the performer (or more specifically, the transactions-implementation-under-test by that

--- a/performers/go/cluster/clusterconnection.go
+++ b/performers/go/cluster/clusterconnection.go
@@ -12,7 +12,7 @@ type Connection struct {
 	bucket  *gocb.Bucket
 }
 
-func Connect(hostname, username, password string, logger *logrus.Logger) (*Connection, error) {
+func Connect(hostname, username, password, bucketName string, logger *logrus.Logger) (*Connection, error) {
 	gocb.SetLogger(&gocbLogger{logger: logger})
 	c, err := gocb.Connect(hostname, gocb.ClusterOptions{
 		Username: username,
@@ -22,8 +22,7 @@ func Connect(hostname, username, password string, logger *logrus.Logger) (*Conne
 		return nil, err
 	}
 
-	//TODO: make the driver send the performer this bucket name
-	b := c.Bucket("default")
+	b := c.Bucket(bucketName)
 	logger.Logf(logrus.InfoLevel, "Bucket set: ", b.Name())
 	err = b.WaitUntilReady(30*time.Second, nil)
 	if err != nil {

--- a/performers/go/sdkservice.go
+++ b/performers/go/sdkservice.go
@@ -22,7 +22,6 @@ type SdkService struct {
 }
 
 func (sdk *SdkService) getConn(connID string) *cluster.Connection {
-	//TODO figure out what to do with null connection string
 	if connID == "" {
 		return sdk.defaultConn
 	}
@@ -42,7 +41,7 @@ func (sdk *SdkService) CreateConnection(ctx context.Context, in *protocol.Create
 	sdk.logger.Log(logrus.InfoLevel, "CreateConnection called")
 
 	sdk.logger.Log(logrus.InfoLevel, "Creating new connection")
-	conn, err := cluster.Connect(in.ClusterHostname, in.ClusterUsername, in.ClusterPassword, sdk.logger)
+	conn, err := cluster.Connect(in.GetClusterHostname(), in.GetClusterUsername(), in.GetClusterPassword(), in.GetBucketName(), sdk.logger)
 	if err != nil {
 		sdk.logger.Logf(logrus.ErrorLevel, "Failed to connect cluster %v", err)
 		return nil, status.Errorf(codes.Aborted, "connection creation failed: %v", err)
@@ -55,6 +54,9 @@ func (sdk *SdkService) CreateConnection(ctx context.Context, in *protocol.Create
 		sdk.conns = make(map[string]*cluster.Connection)
 	}
 	sdk.conns[connID] = conn
+
+	// defaultConn will always be the most recent connection
+	sdk.defaultConn = conn
 
 	return &protocol.CreateConnectionResponse{
 		ProtocolVersion:     "2.0",

--- a/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/utils/ClusterConnection.java
+++ b/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/utils/ClusterConnection.java
@@ -20,8 +20,7 @@ public class ClusterConnection {
         userName = reqData.getClusterUsername();
         password = reqData.getClusterPassword();
         cluster = Cluster.connect(hostname,userName,password);
-        //FIXME: set this in the driver and send it over here
-        bucket = cluster.bucket("default");
+        bucket = cluster.bucket(reqData.getBucketName());
         cluster.waitUntilReady(Duration.ofSeconds(30));
     }
 
@@ -29,8 +28,8 @@ public class ClusterConnection {
         return bucket;
     }
 
-    public Bucket getBucket(String bucketname) {
-        return  cluster.bucket(bucketname);
+    public Bucket getBucket(String bucketName) {
+        return  cluster.bucket(bucketName);
     }
 
     public Cluster getCluster(){

--- a/sdk-driver/src/main/java/com/sdk/SdkDriver.java
+++ b/sdk-driver/src/main/java/com/sdk/SdkDriver.java
@@ -216,6 +216,8 @@ public class SdkDriver {
                             .setClusterHostname(testSuite.connections().cluster().hostname())
                             .setClusterUsername(testSuite.connections().cluster().username())
                             .setClusterPassword(testSuite.connections().cluster().password())
+                            //bucketName is set here rather than in the performer so if it ever needs to be changed it can be done from a single place
+                            .setBucketName(Defaults.DEFAULT_BUCKET)
                             .build();
 
             logger.info("Connecting to performer on {}:{}", testSuite.connections().performer().hostname(), testSuite.connections().performer().port());
@@ -258,7 +260,6 @@ public class SdkDriver {
                 });
 
                 PerfRunRequest.Builder perf = PerfRunRequest.newBuilder()
-                        //TODO refactor the multiple performers bit
                         .setClusterConnectionId(performer.getClusterConnectionId())
                         .setRunForSeconds((int) testSuite.runtimeAsDuration().toSeconds());
 
@@ -317,8 +318,6 @@ public class SdkDriver {
 
                         st.executeUpdate(String.format("INSERT INTO buckets VALUES (to_timestamp(%d), '%s', %d, %d, %d, %d, %d, %d, %d, %d, %d, %d)",
                                 v.timestamp,
-                                //FIXME refactor with FIT-esque version id creation
-                                //sortedResults.get(0).getVersionId(),
                                 run.uuid(),
                                 v.sdkOpsTotal,
                                 v.sdkOpsSuccess,


### PR DESCRIPTION
The bucket to be used when CreateConnection was called used to be set in
the performer, to make it easier to change the name of this bucket it is
now set in the driver

Change-Id: Iadcea50f74e94857c01935e9e1a6b38481ba40a1