### PR TITLE
Add Functionality to Create Doc Pool

### DIFF
--- a/sdk-driver/src/main/java/com/sdk/constants/Defaults.java
+++ b/sdk-driver/src/main/java/com/sdk/constants/Defaults.java
@@ -4,4 +4,9 @@ public class Defaults {
     public final static String DEFAULT_BUCKET = "default";
     public final static String DEFAULT_SCOPE = "_default";
     public final static String DEFAULT_COLLECTION = "_default";
+    // during tests the java performer seemed to be able to do about 450 inserts a second so this seemed
+    // like a good arbitrary number to start off on, if remove tests keep running out of docs or the warmup takes too long this will have to be changed.
+    public final static int docCreateMultiplier = 750;
+    public final static int secPerMin = 60;
+    public final static int secPerHour = 3600;
 }

--- a/sdk-driver/src/main/java/com/sdk/sdk/util/DocCreateThread.java
+++ b/sdk-driver/src/main/java/com/sdk/sdk/util/DocCreateThread.java
@@ -1,0 +1,50 @@
+package com.sdk.sdk.util;
+
+import com.couchbase.client.java.Bucket;
+import com.couchbase.client.java.Cluster;
+import com.couchbase.client.java.Collection;
+import com.couchbase.client.java.Scope;
+import com.couchbase.client.java.json.JsonObject;
+import com.couchbase.client.java.manager.bucket.BucketManager;
+import com.couchbase.client.java.manager.bucket.BucketSettings;
+import com.sdk.constants.Strings;
+import com.sdk.logging.LogUtil;
+import org.slf4j.Logger;
+
+import java.time.Duration;
+
+public class DocCreateThread extends Thread {
+    private final int docNum;
+    private Cluster cluster;
+    private Bucket bucket;
+    private Scope scope;
+    private static final Logger logger = LogUtil.getLogger(DocCreateThread.class);
+
+
+    public DocCreateThread(int docNum, String hostname, String userName, String password, String bucketName, String scopeName) throws Exception{
+        this.docNum =docNum;
+        logger.info("Creating connection to cluster to create document pool");
+        try {
+            this.cluster = Cluster.connect(hostname, userName, password);
+            this.bucket = cluster.bucket(bucketName);
+            this.scope = bucket.scope(scopeName);
+            cluster.waitUntilReady(Duration.ofSeconds(30));
+        }
+        //TODO Discuss better exception to throw
+        catch (Exception err){
+            throw new Exception("Could not connect to cluster for doc pool creation: " + err.getMessage());
+        }
+    }
+
+    @Override
+    public void run() {
+        logger.info("Creating docPool collection");
+        // collection called docPool has to exist
+        Collection collection = scope.collection("docPool");
+        JsonObject input = JsonObject.create().put(Strings.CONTENT_NAME, Strings.INITIAL_CONTENT_VALUE);
+        //TODO add awareness if docs pool already exists, if so flush it of try to make use of documents in it
+        for (int i=0; i < this.docNum; i++){
+            collection.insert("doc_" + i, input);
+        }
+    }
+}


### PR DESCRIPTION
Certain operations like REMOVE need documents to exist in the database
before they can be tested. This commit adds functionality for that to
happen.

It estimates how many documents the Remove operations will need (750 *
number of REMOVE operations in all test runs * horizontal scaling *
number of seconds in runtime) and creates them in a seperate collection.

This is so far untested and might take an extremely long time. It will
definatly take longer than the runtime you have set so be wary.

Change-Id: Ifd0a922e56c5a8a28a3dc36a540dbc816ca4ca1f