### PR TITLE
Add Remove Functionality

### DIFF
--- a/gRPC/sdk_commands.proto
+++ b/gRPC/sdk_commands.proto
@@ -23,10 +23,16 @@ message CommandGet {
   BucketInfo bucketInfo = 2;
 }
 
+message CommandRemove {
+  BucketInfo bucketInfo = 1;
+  string keyPreface = 2;
+}
+
 message SdkCommand {
   oneof command {
     CommandInsert insert = 1;
     CommandGet get = 2;
+    CommandRemove remove = 3;
   }
 }
 

--- a/performers/go/cluster/clusterconnection.go
+++ b/performers/go/cluster/clusterconnection.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"time"
 
-	"github.com/couchbase/gocb/v2"
+	gocb "github.com/couchbase/gocb/v2"
 	"github.com/sirupsen/logrus"
 )
 

--- a/sdk-driver/src/main/java/com/sdk/constants/Defaults.java
+++ b/sdk-driver/src/main/java/com/sdk/constants/Defaults.java
@@ -4,6 +4,9 @@ public class Defaults {
     public final static String DEFAULT_BUCKET = "default";
     public final static String DEFAULT_SCOPE = "_default";
     public final static String DEFAULT_COLLECTION = "_default";
+    public final static String DOCPOOL_COLLECTION = "docPool";
+    public final static String KEY_PREFACE = "doc_";
+
     // during tests the java performer seemed to be able to do about 450 inserts a second so this seemed
     // like a good arbitrary number to start off on, if remove tests keep running out of docs or the warmup takes too long this will have to be changed.
     public final static int docCreateMultiplier = 750;


### PR DESCRIPTION
This remove functionality uses a doc pool which generates a number of
docs to use based on a guess at how many might be needed. This is not
ideal, the next commits should (hopefully) be refactoring the Driver to
be bounded by number of docs rather than runtime.

Change-Id: I3e43ab798c98ada4ce9db8ea0be728645cbcf6d3