### PR TITLE
Refactor Test Bounding

### DIFF
--- a/gRPC/sdk_performer.proto
+++ b/gRPC/sdk_performer.proto
@@ -72,10 +72,12 @@ message PerfRunRequest {
 
     // See PerfRunHorizontalScaling for a discussion of this.  Broadly, it's the number of concurrent transactions
     // required.
+    //TODO send over a number instead of multiple commands
     repeated PerfRunHorizontalScaling horizontalScaling = 2;
 
     // Performer will run until this much time has elapsed.
-    int32 runForSeconds = 3;
+    // want perf runs to be bounded my number of docs for the moment
+    //int32 runForSeconds = 3;
 }
 
 message PerfSingleSdkOpResult {

--- a/performers/go/sdkservice.go
+++ b/performers/go/sdkservice.go
@@ -70,7 +70,10 @@ func (sdk *SdkService) PerfRun(in *protocol.PerfRunRequest, stream protocol.Perf
 	connection := sdk.getConn(in.ClusterConnectionId)
 	sdk.logger.Log(logrus.InfoLevel, connection)
 
-	perf.PerfMarshaller(connection, in, stream, sdk.logger)
+	if err := perf.PerfMarshaller(connection, in, stream, sdk.logger); err != nil {
+		sdk.logger.Logf(logrus.ErrorLevel, "error whilst executing perfRun %v", err)
+		return status.Errorf(codes.Aborted, "error whilst executing perfRun %v", err)
+	}
 
 	return nil
 }

--- a/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/SdkOperation.java
+++ b/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/SdkOperation.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class SdkOperation {
     private String name;
@@ -29,10 +30,10 @@ public class SdkOperation {
             SdkCreateRequest req) {
         this.name = req.getName();
         logger = LogUtil.getLogger(this.name);
-
-        for (int i=0; i< req.getCount(); i++) {
-            performOperation(connection, req.getCommand());
-        }
+        performOperation(connection, req.getCommand());
+//        for (int i=0; i< req.getCount(); i++) {
+//            performOperation(connection, req.getCommand());
+//        }
         SdkCommandResult.Builder response = SdkCommandResult.getDefaultInstance().newBuilderForType();
         return response.build();
     }

--- a/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/perf/PerfMarshaller.java
+++ b/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/perf/PerfMarshaller.java
@@ -1,9 +1,6 @@
 package com.couchbase.sdk.perf;
 
-import com.couchbase.grpc.sdk.protocol.PerfRunHorizontalScaling;
-import com.couchbase.grpc.sdk.protocol.PerfRunRequest;
-import com.couchbase.grpc.sdk.protocol.PerfSingleSdkOpResult;
-import com.couchbase.grpc.sdk.protocol.SdkCommandResult;
+import com.couchbase.grpc.sdk.protocol.*;
 import com.couchbase.sdk.SdkOperation;
 import com.couchbase.sdk.utils.ClusterConnection;
 import com.google.protobuf.Timestamp;
@@ -14,13 +11,17 @@ import org.slf4j.Logger;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 
 public class PerfMarshaller {
     private static final Logger logger = LogUtil.getLogger(PerfMarshaller.class);
-    public static AtomicInteger docPool = new AtomicInteger();
+    private static AtomicInteger docPool = new AtomicInteger();
+    private static ReentrantLock onNextLock = new ReentrantLock();
 
     public static void run(ClusterConnection connection,
                            PerfRunRequest perfRun,
@@ -34,7 +35,8 @@ public class PerfMarshaller {
                     perfRun,
                     perThread,
                     responseObserver,
-                    docPool));
+                    docPool,
+                    onNextLock));
         }
 
         for (PerfRunnerThread perfRunnerThread : runners) {
@@ -47,6 +49,8 @@ public class PerfMarshaller {
         }
         logger.info("All {} threads completed", runners.size());
 
+        docPool.set(0);
+
     }
 
 }
@@ -58,19 +62,23 @@ class PerfRunnerThread extends Thread {
     private final PerfRunHorizontalScaling perThread;
     private final StreamObserver<PerfSingleSdkOpResult> responseObserver;
     private AtomicInteger docPool;
+    private ReentrantLock onNextLock;
+    private HashMap<String, Integer> count;
 
     PerfRunnerThread(int runnerIndex,
                      ClusterConnection connection,
                      PerfRunRequest perfRun,
                      PerfRunHorizontalScaling perThread,
                      StreamObserver<PerfSingleSdkOpResult> responseObserver,
-                     AtomicInteger docPool) {
+                     AtomicInteger docPool,
+                     ReentrantLock onNextLock) {
         this.runnerIndex = runnerIndex;
         this.connection = connection;
         this.perfRun = perfRun;
         this.perThread = perThread;
         this.responseObserver = responseObserver;
         this.docPool = docPool;
+        this.onNextLock = onNextLock;
     }
 
     private static Timestamp.Builder getTimeNow() {
@@ -83,27 +91,51 @@ class PerfRunnerThread extends Thread {
 
     @Override
     public void run() {
-        Instant now = Instant.now();
-        Instant until = now.plus(perfRun.getRunForSeconds(), ChronoUnit.SECONDS);
-        boolean isDone = false;
+        //Instant now = Instant.now();
+        //Instant until = now.plus(perfRun.getRunForSeconds(), ChronoUnit.SECONDS);
+        //boolean isDone = false;
+        SdkOperation operation = new SdkOperation(docPool);
+        count = calculateCount();
 
-        while (!isDone) {
-            for (int i=0; i<perThread.getSdkCommandCount(); i++){
-                PerfSingleSdkOpResult.Builder singleResult = PerfSingleSdkOpResult.newBuilder();
-                singleResult.setInitiated(getTimeNow());
-                SdkOperation operation = new SdkOperation(docPool);
-                SdkCommandResult result = operation.run(connection, perThread.getSdkCommand(i));
+        //FIXME really don't like the way that this is done
+        // uses a map to find out if each count is still active.
+        // Has to do a lot of calculation just to do one operation which isn't ideal
+        while (Collections.max(count.values()) > 0) {
+            for (SdkCreateRequest command : perThread.getSdkCommandList()){
+                if (count.get(command.getName()) > 0) {
+                    PerfSingleSdkOpResult.Builder singleResult = PerfSingleSdkOpResult.newBuilder();
+                    singleResult.setInitiated(getTimeNow());
+                    SdkCommandResult result = operation.run(connection, command);
 
-                singleResult.setFinished(getTimeNow());
-                singleResult.setResults(result.toBuilder());
+                    singleResult.setFinished(getTimeNow());
+                    singleResult.setResults(result.toBuilder());
 
-                responseObserver.onNext(singleResult.build());
+                    onNextLock.lock();
+                    try {
+                        responseObserver.onNext(singleResult.build());
+                    }
+                    finally {
+                        onNextLock.unlock();
+                    }
 
-                if (Instant.now().isAfter(until)) {
-                    isDone = true;
-                    break;
+                    count.replace(command.getName(), count.get(command.getName()) - 1);
                 }
+                //use if bounding tests by runtime
+//                if (Instant.now().isAfter(until)) {
+//                    isDone = true;
+//                    break;
+//                }
             }
         }
+    }
+
+    //calculateCount is run in each thread so that the hashmap does not get shared between them.
+    // This just feels bad, I keep going further and further down a rabbit hole of things I don't like...
+    private HashMap<String, Integer> calculateCount(){
+        HashMap<String, Integer> count = new HashMap<>();
+        for (SdkCreateRequest command : perThread.getSdkCommandList()){
+            count.put(command.getName(),command.getCount());
+        }
+        return count;
     }
 }

--- a/sdk-driver/src/main/java/com/sdk/sdk/util/DocCreateThread.java
+++ b/sdk-driver/src/main/java/com/sdk/sdk/util/DocCreateThread.java
@@ -56,7 +56,7 @@ public class DocCreateThread extends Thread {
         JsonObject input = JsonObject.create().put(Strings.CONTENT_NAME, Strings.INITIAL_CONTENT_VALUE);
         // Starts from 1 because the performer uses addAndGet() to get a doc id, meaning 0 is never used.
         // This behaviour should be shared for all performers.
-        for (int i=1; i < this.docNum; i++){
+        for (int i=1; i < this.docNum + 1; i++){
             collection.insert(Defaults.KEY_PREFACE + i, input);
         }
         cluster.disconnect();

--- a/test-suites/goInsert.yaml
+++ b/test-suites/goInsert.yaml
@@ -1,15 +1,14 @@
 ---
-runtime: "5m"
 implementation:
   language: "go"
   version: "2.3.3"
 variables:
   predefined:
   - name: "horizontal_scaling"
-    value: 2
+    value: 1
   custom:
   - name: "number_of_inserts"
-    value: 50
+    value: 5000
 connections:
   cluster:
     hostname: "10.112.212.101"
@@ -25,9 +24,9 @@ connections:
     password: "password"
     dbName: "perf"
 runs:
-- uuid: "097572b1-0ab4-435a-9250-5c6cca8d23e5"
+- uuid: "097572b1-0ab4-435a-9250-5d6cca8d23e5"
   description: "Insert 50"
   operations:
   - op: "INSERT"
-    count: 50
+    count: 5000
 

--- a/test-suites/javaInsert.yaml
+++ b/test-suites/javaInsert.yaml
@@ -1,5 +1,4 @@
 ---
-runtime: "10s"
 implementation:
   language: "java"
   version: "3.1.4"
@@ -25,9 +24,9 @@ connections:
     password: "password"
     dbName: "perf"
 runs:
-- uuid: "097572b1-0ab4-435a-9250-5c6cca8d23f1"
+- uuid: "097572b1-0ab4-435a-9250-5c6cca8d23f4"
   description: "Insert 50"
   operations:
   - op: "INSERT"
-    count: 50
+    count: 5000
 


### PR DESCRIPTION
Tests used to be bounded by runtime, i.e. run for x seconds. Now they
are bounded by number of doc operations in each run. This change was
made because to allow remove tests to be bounded by runtime we had to
predict how many douments the test would need whic was not ideal.

As a result of this it was found that the Java performer was incorrectly
multithreaded and needed some extra synchronisation.

Also it used to be that every time the performer finished a number of
operations it would send over the time taken to do that number. Now the
performer sends over how long it took to do one operation. This comes
with a lot more over head on the performer side which may affect
throughput numbers. This does not matter too much though as all tests
will suffer the same hit to throughput.

Change-Id: I07493c2aa7d679cbf41faa8ef8f975b085a21fd4