### PR TITLE
Add Java Performer Write Queue

### DIFF
--- a/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/perf/PerfWriteThread.java
+++ b/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/perf/PerfWriteThread.java
@@ -1,0 +1,41 @@
+package com.couchbase.sdk.perf;
+
+import com.couchbase.grpc.sdk.protocol.PerfSingleSdkOpResult;
+import com.sdk.logging.LogUtil;
+import io.grpc.stub.StreamObserver;
+import org.slf4j.Logger;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class PerfWriteThread extends Thread {
+    private final StreamObserver<PerfSingleSdkOpResult> responseObserver;
+    private static ConcurrentLinkedQueue<PerfSingleSdkOpResult> writeQueue;
+    private static AtomicBoolean done;
+    private Logger logger = LogUtil.getLogger(PerfWriteThread.class);
+
+    public PerfWriteThread(
+            StreamObserver<PerfSingleSdkOpResult> responseObserver,
+            ConcurrentLinkedQueue<PerfSingleSdkOpResult> writeQueue,
+            AtomicBoolean done){
+        this.responseObserver = responseObserver;
+        this.writeQueue = writeQueue;
+        this.done = done;
+    }
+
+    @Override
+    public void run() {
+        while(!(writeQueue.isEmpty() && done.get())){
+            if (writeQueue.isEmpty()){
+                try {
+                    Thread.sleep(100);
+                } catch (InterruptedException err) {
+                    logger.error("Writer thread interrupted whilst waiting for results", err);
+                    responseObserver.onError(err);
+                }
+            }else{
+                responseObserver.onNext(writeQueue.remove());
+            }
+        }
+    }
+}

--- a/sdk-driver/src/main/java/com/sdk/SdkDriver.java
+++ b/sdk-driver/src/main/java/com/sdk/SdkDriver.java
@@ -322,7 +322,6 @@ public class SdkDriver {
                     perf.addHorizontalScaling(horizontalScalingBuilt);
                 }
 
-                long startedAll = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
                 var done = new AtomicBoolean(false);
                 var toWrite = new ConcurrentLinkedQueue<PerfSingleSdkOpResult>();
                 var first = new AtomicReference<Tuple2<Timestamp, Long>>(null);
@@ -364,8 +363,6 @@ public class SdkDriver {
                 var sortedResults = toWrite.stream()
                         .sorted(Comparator.comparingInt(a -> a.getInitiated().getNanos()))
                         .collect(Collectors.toList());
-
-                long finishedAll = TimeUnit.NANOSECONDS.toMillis(System.nanoTime());
 
                 var resultsToWrite = processResults(sortedResults, first.get());
 


### PR DESCRIPTION
The java gRPC implementation is not thread safe so having a horizontal
scaling of larger than 1 caused it to error. My previous fix was to use
locking but now each performer thread writes to a ConcurrentLinkedQueue
and a writer thread sends all the data to the performer.

Change-Id: I741d3b9384139c8339cda30cdc651cbf4d5c791d