### PR TITLE
Add Replace to Driver and Java Performer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,9 @@ To generate java stubs:
 `cd performers/go`
 `make proto`
 
+## Notes
+If you want to test multiple types of commands in the same test run, the REMOVE command has to go last.
+This can be done by putting it at the bottom of the operations section of the input `.yaml` file.
+
+Please also note that only one instance of each command is permitted per mixed workload.
+

--- a/gRPC/sdk_commands.proto
+++ b/gRPC/sdk_commands.proto
@@ -10,17 +10,13 @@ option java_multiple_files = true;
 import "sdk_basic.proto";
 
 message CommandInsert {
-  BucketInfo bucketInfo = 3;
-  string contentJson = 4;
+  BucketInfo bucketInfo = 1;
+  string contentJson = 2;
 }
 
 message CommandGet {
-  // PERF_PERFORMER: this can start with "__doc_X", in which case a UUID for XXX should be generated or used automatically by
-  // the performer.  E.g. the first use of "__doc_0" in a transaction should create a new UUID for 0, and then subsequent uses
-  // of "__doc_0" in the same transaction should reuse that UUID.  X will always be an integer.
-  string docId = 1;
-
-  BucketInfo bucketInfo = 2;
+  BucketInfo bucketInfo = 1;
+  string keyPreface = 2;
 }
 
 message CommandRemove {
@@ -28,11 +24,18 @@ message CommandRemove {
   string keyPreface = 2;
 }
 
+message CommandReplace{
+  BucketInfo bucketInfo = 1;
+  string keyPreface = 2;
+  string contentJson = 4;
+}
+
 message SdkCommand {
   oneof command {
     CommandInsert insert = 1;
     CommandGet get = 2;
     CommandRemove remove = 3;
+    CommandReplace replace = 4;
   }
 }
 

--- a/sdk-driver/src/main/java/com/sdk/sdk/util/DocCreateThread.java
+++ b/sdk-driver/src/main/java/com/sdk/sdk/util/DocCreateThread.java
@@ -56,9 +56,7 @@ public class DocCreateThread extends Thread {
             }
             Collection collection = scope.collection(Defaults.DOCPOOL_COLLECTION);
             JsonObject input = JsonObject.create().put(Strings.CONTENT_NAME, Strings.INITIAL_CONTENT_VALUE);
-            // Starts from 1 because the performer uses addAndGet() to get a doc id, meaning 0 is never used.
-            // This behaviour should be shared for all performers.
-            for (int i = 1; i < this.docNum + 1; i++) {
+            for (int i = 0; i < this.docNum; i++) {
                 collection.insert(Defaults.KEY_PREFACE + i, input);
             }
             cluster.disconnect();


### PR DESCRIPTION
Also updated GET's to use the doc pool.

Currently it is possible to have a multi operation workload but only if
there is one of each operation and remove is last in the list of
operations to do. This is because for now most of the tests should just
be single operations.

Change-Id: I6891a3512b1e75b7a7ffeb3a9c8d6158ef2858e1