### PR TITLE
Add Python Performer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+
 # Compiled class file
 *.class
 
@@ -26,6 +29,8 @@ hs_err_pid*
 performers/go/protocol
 performers/java/lib/gRPC/src/main/java
 performers/java/lib/gRPC/target
+*_pb2.py
+*_pb2_grpc.py
 
 #Test Suites
 test-suites/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 database:
-	docker run -d --network host -p 5432:5432 -e POSTGRES_PASSWORD=password --name timedb timescale/timescaledb:latest-pg14
+	docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=password --name timedb timescale/timescaledb:latest-pg14
 	sleep 10;
 	docker exec timedb psql -U postgres -c "CREATE DATABASE perf;"
 	docker exec timedb psql -U postgres -d perf -c "CREATE TABLE IF NOT EXISTS runs (id uuid PRIMARY KEY, datetime timestamp, params jsonb);"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ To generate java stubs:
 
 `make proto`
 
+### Python Stubs
+`cd performers/python`
+
+`make proto`
+
+Please Note: Unfortunately I could not get the generated files to work in a seperate directory so it just dumps them in
+performers/python. If you know how to fix this please do.
+
 ## Notes
 If you want to test multiple types of commands in the same test run, the REMOVE command has to go last.
 This can be done by putting it at the bottom of the operations section of the input `.yaml` file.

--- a/gRPC/sdk_performer.proto
+++ b/gRPC/sdk_performer.proto
@@ -8,7 +8,6 @@ option go_package = "github.com/couchbaselabs/transactions-fit-performer/protoco
 option java_multiple_files = true;
 
 import "sdk_commands.proto";
-import "sdk_basic.proto";
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/empty.proto";
 

--- a/performers/go/service/sdkservice.go
+++ b/performers/go/service/sdkservice.go
@@ -33,7 +33,7 @@ func (sdk *SdkService) getConn(connID string) *cluster.Connection {
 	if conn, isValid := sdk.conns[connID]; isValid {
 		return conn
 	}
-
+	//TODO error here
 	return nil
 }
 

--- a/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/perf/PerfMarshaller.java
+++ b/performers/java/sdk-performer-java/src/main/java/com/couchbase/sdk/perf/PerfMarshaller.java
@@ -8,17 +8,12 @@ import com.couchbase.sdk.logging.LogUtil;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.locks.ReentrantLock;
 
 public class PerfMarshaller {
     private static final Logger logger = LogUtil.getLogger(PerfMarshaller.class);

--- a/performers/python/Makefile
+++ b/performers/python/Makefile
@@ -1,0 +1,5 @@
+proto:
+	mkdir -p protocol
+	python3 -m grpc_tools.protoc -I../../gRPC --python_out=. --grpc_python_out=. ../../gRPC/sdk_basic.proto
+	python3 -m grpc_tools.protoc -I../../gRPC --python_out=. --grpc_python_out=. ../../gRPC/sdk_commands.proto
+	python3 -m grpc_tools.protoc -I../../gRPC --python_out=. --grpc_python_out=. ../../gRPC/sdk_performer.proto

--- a/performers/python/cluster_connection.py
+++ b/performers/python/cluster_connection.py
@@ -1,0 +1,19 @@
+from ast import Pass
+from couchbase.cluster import Cluster
+from couchbase.options import ClusterOptions
+from couchbase.auth import PasswordAuthenticator
+
+from datetime import timedelta
+
+class ClusterConnection():
+    def __init__(self, request, logger):
+        try:
+            logger.info(request.clusterHostname + " " + request.clusterUsername + " " + request.clusterPassword + " " + request.bucketName)
+            opts = ClusterOptions(authenticator=PasswordAuthenticator(request.clusterUsername, request.clusterPassword))
+            self.cluster = Cluster.connect(("couchbase://" + request.clusterHostname), opts)
+            self.cluster.wait_until_ready(timedelta(seconds=30))
+            self.bucket = self.cluster.bucket(request.bucketName)
+        except Exception as e:
+            logger.exception(e)
+            raise Exception(f'Failed to connect to cluster.  Error: {e}')
+

--- a/performers/python/doc_pool_counter.py
+++ b/performers/python/doc_pool_counter.py
@@ -1,0 +1,16 @@
+from threading import Lock
+
+class DocPoolCounter():
+    def __init__(self):
+        self._lock = Lock()
+        self._count = 0
+    
+    def get_and_inc(self):
+        with self._lock:
+            current = self._count
+            self._count += 1
+            return current
+
+    def reset_counter(self):
+        with self._lock:
+            self._counter = 0

--- a/performers/python/exceptions.py
+++ b/performers/python/exceptions.py
@@ -1,0 +1,5 @@
+class ConnectionDictCreation(Exception):
+    pass
+
+class GetConnectionFailed(Exception):
+    pass

--- a/performers/python/main.py
+++ b/performers/python/main.py
@@ -1,0 +1,90 @@
+import sdk_performer_pb2_grpc as performer_grpc
+import sdk_performer_pb2 as sdk_performer_pb2
+from cluster_connection import ClusterConnection
+from exceptions import *
+from perf_marshaller import perf_marshaller
+
+from threading import Thread
+from concurrent import futures
+import logging
+import grpc
+import sys
+import traceback
+import queue
+
+class Listener(performer_grpc.PerformerSdkServiceServicer):
+    def __init__(self):
+        self.logger = logging.getLogger()
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+        handler.setFormatter(formatter)
+        self.logger.addHandler(handler)
+        self.logger.setLevel(logging.INFO)
+        self.conn_cntr = 0
+        self.conns = {}
+        self.default_conn = None
+
+    def createConnection(self, request, context):
+        self.logger.info("Creating new connection")
+
+        try:
+            conn = ClusterConnection(request, self.logger)
+        except Exception as e:
+            raise Exception(e)
+
+        self.conn_cntr += 1
+        conn_id = f"cluster-{self.conn_cntr}"
+        self.conns[conn_id] = conn
+
+        # defaultConn will always be the most recent connections
+        self.default_conn = conn
+
+        return sdk_performer_pb2.CreateConnectionResponse(protocolVersion = "2.0", clusterConnectionId = conn_id)
+
+    def get_connection(self, conn_id):
+        if conn_id == "":
+            return self.default_conn
+        elif self.conns == {}:
+            raise ConnectionDictCreation("The connection dictionary has not been created, has createConnection been called?")
+        elif conn_id in self.conns:
+            return self.conns[conn_id]
+        else:
+            return GetConnectionFailed("Unable to get connection")
+
+            
+
+    def perfRun(self, request, context):
+        self.logger.info("Starting perf run")
+        write_queue = queue.Queue()
+        connection = self.get_connection(request.clusterConnectionId)
+        self.logger.info(connection)
+        perf = Thread(target = perf_marshaller, args = (connection, request, write_queue, self.logger))
+        perf.start()
+        while not(write_queue.empty() and not(perf.is_alive())):
+            yield write_queue.get()
+    
+    def Exit(self, request, context):
+        None
+
+
+
+def serve():
+    print("called serve")
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
+    print("made serverobject")
+    performer_grpc.add_PerformerSdkServiceServicer_to_server(Listener(), server)
+    print("added listerner")
+    server.add_insecure_port("[::]:8060")
+    print("add port")
+    server.start()
+    print("started server")
+    server.wait_for_termination()
+
+if __name__ == "__main__":
+    try:
+        print("table")
+        serve()
+    except Exception:
+        exc_info = sys.exc_info()
+        tb = ''.join(traceback.format_tb(exc_info[2]))
+        print(f'Exception info: {exc_info[1]}\nTraceback:\n{tb}')

--- a/performers/python/perf_marshaller.py
+++ b/performers/python/perf_marshaller.py
@@ -1,0 +1,46 @@
+from os import times
+from webbrowser import get
+import doc_pool_counter
+from sdk_operation import perform_operation
+from threading import Thread
+from google.protobuf.timestamp_pb2 import Timestamp
+import sdk_performer_pb2_grpc as performer_grpc
+import sdk_performer_pb2
+import logging
+
+def get_time_now():
+    timestamp = Timestamp()
+    timestamp.GetCurrentTime()
+    return timestamp
+
+def perf_marshaller(connection, perf_request, write_queue, logger):
+    get_counter = doc_pool_counter.DocPoolCounter()
+    replace_counter = doc_pool_counter.DocPoolCounter()
+    remove_counter = doc_pool_counter.DocPoolCounter()
+    runners = []
+    for request in perf_request.horizontalScaling:
+        runners.append(Thread(target = perf_runner, args = (connection, request, get_counter, replace_counter, remove_counter, write_queue, logger)))
+
+    logger.info(f"Starting {len(runners)} thread(s)")
+
+    for per_thread in runners:
+        per_thread.start()
+
+    for per_thread in runners:
+        per_thread.join()
+
+    logger.info(f"All {len(runners)} threads completed")
+
+    get_counter.reset_counter()
+    replace_counter.reset_counter()
+    remove_counter.reset_counter()
+
+
+
+def perf_runner(connection, request, get_counter, replace_counter, remove_counter, write_queue, logger):
+    for command in request.sdkCommand:
+        for _ in range(command.count):
+            command_initiated = get_time_now()
+            perf_result = perform_operation(connection, command, get_counter, replace_counter, remove_counter, logger)
+            command_finished = get_time_now()
+            write_queue.put(sdk_performer_pb2.PerfSingleSdkOpResult(results = perf_result, initiated = command_initiated, finished = command_finished))

--- a/performers/python/sdk_operation.py
+++ b/performers/python/sdk_operation.py
@@ -1,0 +1,31 @@
+import sdk_performer_pb2
+import logging
+import json
+import uuid
+from couchbase.options import InsertOptions
+
+def perform_operation(connection, command, get_counter, replace_counter, remove_counter, logger):
+    if command.name == "INSERT":
+        request = command.command.insert
+        collection = connection.bucket.scope(request.bucketInfo.scopeName).collection(request.bucketInfo.collectionName)
+        logger.info(f"Performing insert operation on bucket {request.bucketInfo.bucketName} on collection {request.bucketInfo.collectionName}")
+        collection.insert(str(uuid.uuid4()), request.contentJson)
+        return sdk_performer_pb2.SdkCommandResult()
+    if command.name == "GET":
+        request = command.command.get
+        collection = connection.bucket.scope(request.bucketInfo.scopeName).collection(request.bucketInfo.collectionName)
+        logger.info(f"Performing get operation on bucket {request.bucketInfo.bucketName} on collection {request.bucketInfo.collectionName}")
+        collection.get((request.keyPreface + str(get_counter.get_and_inc())))
+        return sdk_performer_pb2.SdkCommandResult()
+    if command.name == "REMOVE":
+        request = command.command.remove
+        collection = connection.bucket.scope(request.bucketInfo.scopeName).collection(request.bucketInfo.collectionName)
+        logger.info(f"Performing remove operation on bucket {request.bucketInfo.bucketName} on collection {request.bucketInfo.collectionName}")
+        collection.remove(request.keyPreface + str(remove_counter.get_and_inc()))
+        return sdk_performer_pb2.SdkCommandResult()
+    if command.name == "REPLACE":
+        request = command.command.replace
+        collection = connection.bucket.scope(request.bucketInfo.scopeName).collection(request.bucketInfo.collectionName)
+        logger.info(f"Performing replace operation on bucket {request.bucketInfo.bucketName} on collection {request.bucketInfo.collectionName}")
+        collection.replace(request.keyPreface + str(replace_counter.get_and_inc()), request.contentJson)
+        return sdk_performer_pb2.SdkCommandResult()

--- a/sdk-driver/src/main/java/com/sdk/SdkDriver.java
+++ b/sdk-driver/src/main/java/com/sdk/SdkDriver.java
@@ -66,18 +66,18 @@ record TestSuite(Implementation implementation, Variables variables, Connections
             return (Integer) predefinedVar(PredefinedVariable.PredefinedVariableName.HORIZONTAL_SCALING);
         }
 
+        record PredefinedVariable(PredefinedVariableName name, Object value) {
+            enum PredefinedVariableName {
+                @JsonProperty("horizontal_scaling") HORIZONTAL_SCALING,
+            }
+        }
+
         private Object predefinedVar(PredefinedVariable.PredefinedVariableName name) {
             return predefined.stream()
                     .filter(v -> v.name == name)
                     .findFirst()
                     .map(v -> v.value)
                     .orElseThrow(() -> new IllegalArgumentException("Predefined variable " + name + " not found"));
-        }
-
-        record PredefinedVariable(PredefinedVariableName name, Object value) {
-            enum PredefinedVariableName {
-                @JsonProperty("horizontal_scaling") HORIZONTAL_SCALING,
-            }
         }
 
         record CustomVariable(String name, Object value) {


### PR DESCRIPTION
Add a python performer that can execute INSERT, GET, REMOVE and REPLACE
operations. The way that gRPC is implemented in python is a little
different so the performer threads write the timeings to a queue (like
the java performer) but the the main function sends these back to the
driver rather than a seperate thread.

Change-Id: Ib4c5fb5f3788b525668235ccc3448d0b620be809