### PR TITLE
Limit The Amount of Metrics Data Written to the Database

### DIFF
--- a/sdk-driver/src/main/java/com/sdk/SdkDriver.java
+++ b/sdk-driver/src/main/java/com/sdk/SdkDriver.java
@@ -438,19 +438,22 @@ public class SdkDriver {
 
                 });
                 logger.info("Completed Writing Perf Data");
-                toWrite.forEach(v -> {
-                    try (var st = conn.createStatement()) {
-                        var initiated = TimeUnit.NANOSECONDS.toMicros(grpcTimestampToNanos(v.getInitiated()));
-                        var finished = TimeUnit.NANOSECONDS.toMicros(grpcTimestampToNanos(v.getFinished()));
-                        st.executeUpdate(String.format("INSERT INTO metrics VALUES (to_timestamp(%d), '%s', '%s')",
-                                initiated - finished,
-                                run.uuid(),
-                                v.getResults().getLog()
-                        ));
-                    } catch (SQLException throwables) {
-                        throwables.printStackTrace();
+                int counter = 0;
+                for (PerfSingleSdkOpResult result : toWrite){
+                    if (counter % 1000 == 0){
+                        try (var st = conn.createStatement()) {
+                            var initiated = TimeUnit.NANOSECONDS.toMicros(grpcTimestampToNanos(result.getInitiated()));
+                            var finished = TimeUnit.NANOSECONDS.toMicros(grpcTimestampToNanos(result.getFinished()));
+                            st.executeUpdate(String.format("INSERT INTO metrics VALUES (to_timestamp(%d), '%s', '%s')",
+                                    initiated - finished,
+                                    run.uuid(),
+                                    result.getResults().getLog()
+                            ));
+                        } catch (SQLException throwables) {
+                            throwables.printStackTrace();
+                        }
                     }
-                });
+                }
                 logger.info("Completed Writing Metric Data");
             }
 


### PR DESCRIPTION
Before every single operations metric data would be written to the
database and this took up a lot of time. For the purposes of testing I
am limiting it to 1 in every thousand.

Change-Id: I9206be670f8bfe2e8ab72b459fc760d21e7ea658